### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Qiita API v2 client library written in Golang.
 
 ## Install
 ```
-go get -u github.com/ktsujichan/qiita-sdk-go
+go get -u github.com/ktsujichan/qiita-sdk-go/qiita
 ```
 
 ## Library


### PR DESCRIPTION
```
$ go get -u github.com/ktsujichan/qiita-sdk-go
package github.com/ktsujichan/qiita-sdk-go: no Go files in /Users/masutaka/go/src/github.com/ktsujichan/qiita-sdk-go
```

でしたので、直してみました。
