### PR TITLE
Enable to unset query to ListItems()

### DIFF
--- a/qiita/item.go
+++ b/qiita/item.go
@@ -63,7 +63,9 @@ func (c *Client) ListItems(ctx context.Context, page, perPage uint, query string
 	values := url.Values{}
 	values.Add("page", fmt.Sprint(page))
 	values.Add("per_page", fmt.Sprint(perPage))
-	values.Add("query", query)
+	if query != "" {
+		values.Add("query", query)
+	}
 	rawQuery := values.Encode()
 	res, err := c.get(ctx, "/api/v2/items", &rawQuery)
 	if err != nil {


### PR DESCRIPTION
## 背景

https://github.com/masutaka/qiita-team-feed で Qiita:Team のフィードを生成するアプリを作っています。Qiita:Team のダッシュボードをフィード化して、サクサク読むことが目的です。

query に `"*"` を渡すと、一見 query なしと同じ動きをしますが、時々結果が異なることに気づきました。

https://qiita.com/api/v2/docs#get-apiv2items や http://blog.qiita.com/post/101162528979/new-qiita-search には、解決策はありませんでした。

## 変更点

query に空文字列を渡したときは、API に query を指定しないようにしました。ちなみに本当に空文字列を指定すると、何も返って来ませんでした。

## 悩んだこと

変更方法がダサいのは認めます。

ListItems() の引数を ItemParameters といった構造体にして、page, perPage, query ともに Optional な入力にしたほうが良いのかもしれません。

```go
type ItemParameters struct {
	page uint
	perPage uint
	query string
}

func (c *Client) ListItems(ctx context.Context, params ItemParameters) (*Items, error)
```

ただ、そうすると他の関数と使い方が変わってしまうため、一旦今回の方法で PR を出すことにしました。

Qiita / Qiita:Team は検索に Elasticsearch を使っていると聞いたことがあります。query の仕様はそれに依存しているのかもしれません。
